### PR TITLE
Switch back from adoptjdk to openjdk

### DIFF
--- a/10-jdk.Dockerfile
+++ b/10-jdk.Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk10:latest
+FROM openjdk:10-jdk
 
 EXPOSE 8080 8081 5005
 


### PR DESCRIPTION
- because adoptjdk currently leads to problems
  when generating excel files with apache POI
  (or when generating PDFs, also see
  https://github.com/AdoptOpenJDK/openjdk-build/issues/682)