### PR TITLE
Remove coloring due to missing support on non-interactive shells

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -25,30 +25,10 @@ $JAVA_OPTS"
 
 echo "Java launch options: $OPTS"
 
-red="$(tput setaf 1)"
-yellow="$(tput setaf 3)"
-reset="$(tput sgr0)"
-bold="$(tput bold)"
-
-function warn() {
-    echo
-    echo "${yellow}********************************************************************************${reset}"
-    echo
-    echo -en "  $1"
-    echo
-    echo
-    echo "${yellow}********************************************************************************${reset}"    
-}
-
-function error() {
-	echo
-    echo "${red}${bold}ERROR: ${reset}$1"    
-}
-
 if [ -f "$SERVICE_JAR" ]; then
 	exec java $OPTS -jar $SERVICE_JAR
 elif [ -d "$SERVICE_FOLDER" ]; then
 	exec java $OPTS -cp $SERVICE_FOLDER org.springframework.boot.loader.JarLauncher
 else
-	error "Cannot start: Must supply either $SERVICE_JAR or $SERVICE_FOLDER"
+	echo "ERROR: Cannot start: Must supply either $SERVICE_JAR or $SERVICE_FOLDER"
 fi


### PR DESCRIPTION
Coloring support is not widely supported so the startup will
produce warnings on the console starting the container. Therefore
this is removed.

Also the warn() function was not used and is now removed.